### PR TITLE
Incluye objetos magicos  y categorías en el mismo servicio

### DIFF
--- a/src/main/java/com/devathon/slytherin/controllers/MagicObjectController.java
+++ b/src/main/java/com/devathon/slytherin/controllers/MagicObjectController.java
@@ -90,4 +90,19 @@ public class MagicObjectController {
         MagicObjectPaginatorResponseDto response = magicObjectService.getByCategory(category, page, size);
         return ResponseEntity.ok(response);
     }
+
+    @Operation(
+            summary = "Obtener objetos mágicos con detalles por categoría",
+            description = "Devuelve una lista paginada de objetos mágicos filtrados por categoría, incluyendo detalles como la categoría."
+    )
+    @ApiResponse(responseCode = "200", description = "Lista de objetos mágicos devuelta con éxito")
+    @ApiResponse(responseCode = "400", description = "Solicitud inválida")
+    @GetMapping("/with-categories")
+    public ResponseEntity<MagicObjectPaginatorResponseDto> getMagicObjectsWithCategories(
+            @RequestParam(required = false) String category,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        MagicObjectPaginatorResponseDto response = magicObjectService.getByCategoryWithDetails(category, page, size);
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/com/devathon/slytherin/exceptions/GlobalExceptionController.java
+++ b/src/main/java/com/devathon/slytherin/exceptions/GlobalExceptionController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.NoHandlerFoundException;
+import org.springframework.orm.jpa.JpaSystemException;
 
 import java.util.Collections;
 import java.util.List;
@@ -109,6 +110,17 @@ public class GlobalExceptionController {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponse);
     }
 
+    @ExceptionHandler(JpaSystemException.class)
+    public ResponseEntity<ErrorResponse> handleJpaSystemException(JpaSystemException ex, HttpServletRequest request) {
+        ErrorResponse errorResponse = new ErrorResponse(
+            "DATABASE_ERROR",
+            "Error al acceder a la base de datos",
+            List.of("Detalle: " + ex.getMostSpecificCause().getMessage(), "Ruta: " + request.getRequestURI())
+        );
+
+        log.error("Error de base de datos en la ruta [{}]: {}", request.getRequestURI(), ex.getMessage(), ex);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
+    }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleException(Exception ex, HttpServletRequest request) {

--- a/src/main/java/com/devathon/slytherin/models/MagicObjectModel.java
+++ b/src/main/java/com/devathon/slytherin/models/MagicObjectModel.java
@@ -22,6 +22,7 @@ public class MagicObjectModel {
     @Column(nullable = false, length = 250)
     private String short_description;
     @Lob
+    @Basic(fetch = FetchType.EAGER)
     @Column(nullable = true)
     private String long_description;
     @ManyToOne

--- a/src/main/java/com/devathon/slytherin/services/MagicObjectService.java
+++ b/src/main/java/com/devathon/slytherin/services/MagicObjectService.java
@@ -83,6 +83,25 @@ public class MagicObjectService {
     }
 
     @Transactional(readOnly = true)
+    public MagicObjectPaginatorResponseDto getByCategoryWithDetails(String category, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<MagicObjectModel> magicObjectPage;
+
+        if (category != null && !category.isEmpty()) {
+            magicObjectPage = magicObjectRepository.findByCategoryName(category, pageable);
+        } else {
+            magicObjectPage = magicObjectRepository.findAll(pageable);
+        }
+
+        List<MagicObjectResponseDto> magicObjectDtos = magicObjectPage.getContent()
+                .stream()
+                .map(magicObjectMapper::toMagicObjectDto)
+                .collect(Collectors.toList());
+
+        return new MagicObjectPaginatorResponseDto(magicObjectDtos, magicObjectPage.getTotalPages(), magicObjectPage.getSize());
+    }
+
+    @Transactional(readOnly = true)
     public MagicObjectPaginatorResponseDto getUnsoldMagicObjects(int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
         Page<MagicObjectModel> magicObjectPage = magicObjectRepository.findByPurchased(false, pageable);


### PR DESCRIPTION
Incluir objetos y categorías en el mismo servicio

Este PR incluye los siguientes cambios:
- Se unifican los objetos mágicos y las categorías en un solo servicio.
- Se agrega un nuevo endpoint `/api/magicobject/with-categories`. el anterior endpoint se mantiene
- Se evita el error relacionado con el acceso al LOB stream.
